### PR TITLE
Fix readme's cron command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Deployment scripts for g0v rumors project
 3. `docker-compose up -d`
 4. `crontab -e` and add
 ```
-0 0 1 */1 * docker run -v /var/www/cofacts:/var/www/cofacts -v /etc/letsencrypt:/etc/letsencrypt -v /etc/ssl/certs:/etc/ssl/certs -v /var/log:/var/log -it certbot/certbot certonly --webroot -w /var/www/cofacts -d cofacts.g0v.tw -m <your@email> --agree-tos --non-interactive >> /var/log/cron.log 2>&1
-0 0 1 */1 * docker run -v /var/www/cofacts:/var/www/cofacts -v /etc/letsencrypt:/etc/letsencrypt -v /etc/ssl/certs:/etc/ssl/certs -v /var/log:/var/log -it certbot/certbot certonly --webroot -w /var/www/cofacts -d cofacts-api.g0v.tw -m <your@email> --agree-tos --non-interactive >> /var/log/cron.log 2>&1
-0 0 2 */1 * cd /home/docker/rumors-deploy;  docker-compose restart nginx
+0 0 1 * * docker run --rm -v /var/www/cofacts:/var/www/cofacts -v /etc/letsencrypt:/etc/letsencrypt -v /etc/ssl/certs:/etc/ssl/certs -v /var/log:/var/log certbot/certbot certonly --webroot -w /var/www/cofacts -d cofacts.g0v.tw -m <your@email> --agree-tos --non-interactive >> /var/log/cron.log 2>&1
+0 0 1 * * docker run --rm -v /var/www/cofacts:/var/www/cofacts -v /etc/letsencrypt:/etc/letsencrypt -v /etc/ssl/certs:/etc/ssl/certs -v /var/log:/var/log certbot/certbot certonly --webroot -w /var/www/cofacts -d cofacts-api.g0v.tw -m <your@email> --agree-tos --non-interactive >> /var/log/cron.log 2>&1
+0 0 2 * * cd /home/docker/rumors-deploy;  docker-compose restart nginx
 ```
 
 ## Updating any image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,15 +15,6 @@ services:
       - "/var/log:/var/log"
     restart: always
 
-  certbot:
-    image: certbot/certbot
-    volumes:
-      - "./volumes/certbot/renew-cron:/etc/cron.d/renew-cron"
-      - "/etc/letsencrypt:/etc/letsencrypt"
-      - "/etc/ssl/certs:/etc/ssl/certs"
-      - "/var/log:/var/log"
-    restart: always
-
   site:
     image: mrorz/rumors-site
     environment:


### PR DESCRIPTION
- Should not use `-it` because cron jobs has no input device.
- Add `--rm` to remove one-off containers
- Remove redundant `/1` after `*`
