### PR TITLE
Supporting en & zh site images

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -15,21 +15,42 @@ services:
       - "/var/log:/var/log"
     restart: always
 
-  site:
-    image: mrorz/rumors-site
+  site-en:
+    image: cofacts/rumors-site:latest-en
     environment:
       - PORT=3000
       - ROLLBAR_SERVER_TOKEN=CHANGE_ME
       - ROLLBAR_ENV=production
       - NODE_ENV=production
       - PUBLIC_API_URL=https://cofacts-api.g0v.tw
-      - PUBLIC_APP_ID=RUMORS_SITE
       - PUBLIC_GA_TRACKER=UA-98468513-1
-
     restart: always
 
-  site-staging:
-    image: mrorz/rumors-site:staging
+  site-zh:
+    image: cofacts/rumors-site:latest-tw
+    environment:
+      - PORT=3000
+      - ROLLBAR_SERVER_TOKEN=CHANGE_ME
+      - ROLLBAR_ENV=production
+      - NODE_ENV=production
+      - PUBLIC_API_URL=https://cofacts-api.g0v.tw
+      - PUBLIC_GA_TRACKER=UA-98468513-1
+    restart: always
+
+  site-staging-en:
+    image: cofacts/rumors-site:dev-en
+    environment:
+      - PORT=3000
+      - ROLLBAR_SERVER_TOKEN=CHANGE_ME
+      - ROLLBAR_ENV=staging
+      - NODE_ENV=production
+      - PUBLIC_API_URL=https://cofacts-api.hacktabl.org
+      - PUBLIC_APP_ID=RUMORS_SITE
+      - PUBLIC_GA_TRACKER=UA-98468513-5
+    restart: always
+
+  site-staging-zh:
+    image: cofacts/rumors-site:dev-tw
     environment:
       - PORT=3000
       - ROLLBAR_SERVER_TOKEN=CHANGE_ME

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -2,14 +2,13 @@ version: '2'
 services:
 
   site:
-    image: mrorz/rumors-site
+    image: cofacts/rumors-site:latest-en
     environment:
       - PORT=3000
       - ROLLBAR_SERVER_TOKEN=
       - ROLLBAR_ENV=
       - NODE_ENV=production
       - PUBLIC_API_URL=http://api:5000
-      - PUBLIC_APP_ID=RUMORS_SITE
       - PUBLIC_GA_TRACKER=
     ports:
       - "3000:3000"

--- a/volumes/nginx/sites-enabled/rumors-site
+++ b/volumes/nginx/sites-enabled/rumors-site
@@ -1,3 +1,8 @@
+map $http_accept_language $lang_postfix {
+  default -en;
+  ~*^zh -zh;
+}
+
 server {
   listen 80 default_server;
   listen [::]:80 default_server;
@@ -34,7 +39,7 @@ server {
     proxy_redirect off;
     proxy_read_timeout 240s;
 
-    proxy_pass http://site:3000/;
+    proxy_pass http://site${lang_postfix}:3000/;
   }
 
   location ~ /.well-known {

--- a/volumes/nginx/sites-enabled/rumors-site-en
+++ b/volumes/nginx/sites-enabled/rumors-site-en
@@ -1,0 +1,44 @@
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+  server_name en.cofacts.g0v.tw;
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
+  server_name en.cofacts.g0v.tw;
+
+  ssl_certificate /etc/letsencrypt/live/cofacts.g0v.tw/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/cofacts.g0v.tw/privkey.pem;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_dhparam /etc/ssl/certs/dhparam.pem;
+  ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:SSL:50m;
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  add_header Strict-Transport-Security max-age=15768000;
+
+  location / {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_http_version 1.1;
+    proxy_max_temp_file_size 0;
+    proxy_redirect off;
+    proxy_read_timeout 240s;
+
+    proxy_pass http://site-en:3000/;
+  }
+
+  location ~ /.well-known {
+    allow all;
+    root /var/www/cofacts;
+  }
+}

--- a/volumes/nginx/sites-enabled/rumors-site-staging
+++ b/volumes/nginx/sites-enabled/rumors-site-staging
@@ -1,3 +1,8 @@
+map $http_accept_language $lang_postfix {
+  default -en;
+  ~*^zh -zh;
+}
+
 server {
   listen 80;
   listen [::]:80;
@@ -10,9 +15,7 @@ server {
   }
 
   location ~* / {
-    #try_files $uri $uri/ =404;
-    #root /var/www/cofacts/;
-    proxy_pass http://site-staging:3000;
+    proxy_pass http://site-staging${lang_postfix}:3000;
   }
 
   location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {

--- a/volumes/nginx/sites-enabled/rumors-site-zh
+++ b/volumes/nginx/sites-enabled/rumors-site-zh
@@ -1,0 +1,44 @@
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+  server_name zh.cofacts.g0v.tw;
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
+  server_name zh.cofacts.g0v.tw;
+
+  ssl_certificate /etc/letsencrypt/live/cofacts.g0v.tw/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/cofacts.g0v.tw/privkey.pem;
+
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+  ssl_dhparam /etc/ssl/certs/dhparam.pem;
+  ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:SSL:50m;
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  add_header Strict-Transport-Security max-age=15768000;
+
+  location / {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-NginX-Proxy true;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_http_version 1.1;
+    proxy_max_temp_file_size 0;
+    proxy_redirect off;
+    proxy_read_timeout 240s;
+
+    proxy_pass http://site-zh:3000/;
+  }
+
+  location ~ /.well-known {
+    allow all;
+    root /var/www/cofacts;
+  }
+}


### PR DESCRIPTION
- Replace legacy `mrorz/rumors-site` docker repo with `cofacts/rumors-site`
- Production docker-compose: change `site` to `site-en` and `site-zh`, `site-staging` to `site-staging-en` and `site-staging-zh`
- Add browser language detection in rumors-site nginx
- Add zh.cofacts.g0v.tw and en.cofacts.g0v.tw sites