### PR TITLE
Add GA related env vars and volume mount

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -99,8 +99,8 @@ services:
       - GITHUB_CALLBACK_URL=CHANGE_ME
       - URL_RESOLVER_URL=url-resolver:4000
       - GOOGLE_OAUTH_KEY_PATH=/data/service-account-key.json
-      - GA_WEB_VIEW_ID=
-      - GA_LINE_VIEW_ID=
+      - GA_WEB_VIEW_ID=CHANGE_ME
+      - GA_LINE_VIEW_ID=CHANGE_ME
 
       # Apollo engine
       - ENGINE_API_KEY=CHANGE_ME
@@ -132,8 +132,8 @@ services:
       - GITHUB_CALLBACK_URL=CHANGE_ME
       - URL_RESOLVER_URL=url-resolver:4000
       - GOOGLE_OAUTH_KEY_PATH=/data/service-account-key.json
-      - GA_WEB_VIEW_ID=
-      - GA_LINE_VIEW_ID=
+      - GA_WEB_VIEW_ID=CHANGE_ME
+      - GA_LINE_VIEW_ID=CHANGE_ME
     volumes:
       - "./volumes/api:/data"
     restart: always

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -98,10 +98,14 @@ services:
       - GITHUB_SECRET=CHANGE_ME
       - GITHUB_CALLBACK_URL=CHANGE_ME
       - URL_RESOLVER_URL=url-resolver:4000
+      - GOOGLE_OAUTH_KEY_PATH=/data/service-account-key.json
+      - GA_WEB_VIEW_ID=
+      - GA_LINE_VIEW_ID=
 
       # Apollo engine
       - ENGINE_API_KEY=CHANGE_ME
-
+    volumes:
+      - "./volumes/api:/data"
     restart: always
 
   api-staging:
@@ -127,6 +131,11 @@ services:
       - GITHUB_SECRET=CHANGE_ME
       - GITHUB_CALLBACK_URL=CHANGE_ME
       - URL_RESOLVER_URL=url-resolver:4000
+      - GOOGLE_OAUTH_KEY_PATH=/data/service-account-key.json
+      - GA_WEB_VIEW_ID=
+      - GA_LINE_VIEW_ID=
+    volumes:
+      - "./volumes/api:/data"
     restart: always
 
   db:

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -41,6 +41,11 @@ services:
       - GITHUB_SECRET=
       - GITHUB_CALLBACK_URL=http://localhost:5000/callback/github
       - URL_RESOLVER_URL=url-resolver:4000
+      - GOOGLE_OAUTH_KEY_PATH=/data/service-account-key.json
+      - GA_WEB_VIEW_ID=
+      - GA_LINE_VIEW_ID=
+    volumes:
+      - "./volumes/api:/data"
     ports:
       - "5000:5000"
     depends_on:

--- a/volumes/api/.gitkeep
+++ b/volumes/api/.gitkeep
@@ -1,0 +1,4 @@
+This directory will be mounted to `/data` in rumors-api's docker container.
+
+Please put google service account key file (json) in this directory and modify docker-compose.yml's
+GOOGLE_OAUTH_KEY_PATH as needed.


### PR DESCRIPTION
1. Add google analytics related env vars in docker-compose sample files
2. Mount `volumes/api` to `/data` in API server container