### PR TITLE
Setup x-forwarded-proto header

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -101,7 +101,8 @@ services:
       - GOOGLE_OAUTH_KEY_PATH=/data/service-account-key.json
       - GA_WEB_VIEW_ID=CHANGE_ME
       - GA_LINE_VIEW_ID=CHANGE_ME
-
+      - TRUST_PROXY_HEADERS=1
+      - COOKIE_SAMESITE_NONE=1
       # Apollo engine
       - ENGINE_API_KEY=CHANGE_ME
     volumes:
@@ -134,6 +135,8 @@ services:
       - GOOGLE_OAUTH_KEY_PATH=/data/service-account-key.json
       - GA_WEB_VIEW_ID=CHANGE_ME
       - GA_LINE_VIEW_ID=CHANGE_ME
+      - TRUST_PROXY_HEADERS=1
+      - COOKIE_SAMESITE_NONE=1
     volumes:
       - "./volumes/api:/data"
     restart: always

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -44,6 +44,8 @@ services:
       - GOOGLE_OAUTH_KEY_PATH=/data/service-account-key.json
       - GA_WEB_VIEW_ID=
       - GA_LINE_VIEW_ID=
+      - TRUST_PROXY_HEADERS=
+      - COOKIE_SAMESITE_NONE=
     volumes:
       - "./volumes/api:/data"
     ports:

--- a/volumes/nginx/sites-enabled/rumors-api
+++ b/volumes/nginx/sites-enabled/rumors-api
@@ -24,6 +24,7 @@ server {
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto "https"; # SSL termination on nginx
     proxy_set_header Host $host;
     proxy_set_header X-NginX-Proxy true;
     proxy_set_header Upgrade $http_upgrade;

--- a/volumes/nginx/sites-enabled/rumors-api
+++ b/volumes/nginx/sites-enabled/rumors-api
@@ -50,6 +50,7 @@ server {
 
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto; # From cloudflare
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header Host $host;
     proxy_set_header X-NginX-Proxy true;

--- a/volumes/nginx/sites-enabled/rumors-api-staging
+++ b/volumes/nginx/sites-enabled/rumors-api-staging
@@ -7,5 +7,6 @@ server {
   location ~* {
     add_header X-Robots-Tag "noindex, nofollow";
     proxy_pass http://api-staging:5000;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto; # From cloudflare
   }
 }


### PR DESCRIPTION
Related to cofacts/rumors-api#211.

Koa relies on `X-Forarded-Proto` when setting up secuire cookies. This PR:
- Sets required env variable to enable samesite cookie in API servers
- Sets `X-Forwarded-Proto` on nginx reverse proxy so that Koa can get it
    - `cofacts-api.g0v.tw`: SSL terminates on nginx server, thus we can directly set `X-Forwarded-Proto` to `https` for HTTPS connections.
    - `api.cofacts.org`, `cofacts-api.hacktabl.org`, `dev-api.cofacts.org`: SSL terminates at Cloudflare.
        - Cloudflare [do send `X-Forwarded-Proto`](https://support.cloudflare.com/hc/en-us/articles/200170986-How-does-Cloudflare-handle-HTTP-Request-headers-)
        - We forward Cloudflare's `X-Forwarded-Proto` to koa server in this case.

## Network topology

##### cofacts-api.g0v.tw
This domain is managed by g0v.
> Browser -- HTTPS --> nginx -- HTTP (with x-forwarded-proto by nginx) --> rumors-api Koa

##### api.cofacts.org, dev-api.cofacts.org, cofacts-api.hacktabl.org
These domains are managed under Cloudflare.
> Browser -- HTTPS --> Cloudflare -- HTTP (with x-forwarded-proto by Cloudflare) --> nginx -- HTTP (with x-forwarded-proto by nginx) --> rumors-api Koa
