### PR TITLE
Fix nginx include

### DIFF
--- a/volumes/nginx/sites-enabled/rumors-site
+++ b/volumes/nginx/sites-enabled/rumors-site
@@ -24,16 +24,16 @@ server {
   ssl_stapling_verify on;
   add_header Strict-Transport-Security max-age=15768000;
 
-  include ../include/server.conf;
+  include include/server.conf;
 
   location /_next {
-    include ../include/next.conf;
+    include include/next.conf;
     proxy_pass http://site-zh:3000;
   }
 
   location / {
-    include ../include/index.conf;
-    include ../include/index-prod.conf;
+    include include/index.conf;
+    include include/index-prod.conf;
 
     proxy_pass http://site-zh:3000;
 
@@ -53,16 +53,16 @@ server {
   listen [::]:80;
   server_name cofacts.org cofacts.tw;
 
-  include ../include/server.conf;
+  include include/server.conf;
 
   location /_next {
-    include ../include/next.conf;
+    include include/next.conf;
     proxy_pass http://site-zh:3000;
   }
 
   location / {
-    include ../include/index.conf;
-    include ../include/index-prod.conf;
+    include include/index.conf;
+    include include/index-prod.conf;
 
     proxy_pass http://site-zh:3000;
 
@@ -77,16 +77,16 @@ server {
   listen [::]:80;
   server_name en.cofacts.org en.cofacts.tw;
 
-  include ../include/server.conf;
+  include include/server.conf;
 
   location /_next {
-    include ../include/next.conf;
+    include include/next.conf;
     proxy_pass http://site-en:3000;
   }
 
   location / {
-    include ../include/index.conf;
-    include ../include/index-prod.conf;
+    include include/index.conf;
+    include include/index-prod.conf;
 
     proxy_pass http://site-en:3000;
 

--- a/volumes/nginx/sites-enabled/rumors-site-staging
+++ b/volumes/nginx/sites-enabled/rumors-site-staging
@@ -5,16 +5,16 @@ server {
 
   server_name cofacts.hacktabl.org dev.cofacts.org dev.cofacts.tw;
 
-  include ../include/server.conf;
+  include include/server.conf;
 
   location /_next {
-    include ../include/next.conf;
+    include include/next.conf;
     proxy_pass http://site-staging-zh:3000;
   }
 
   location / {
-    include ../include/index.conf;
-    include ../include/index-staging.conf;
+    include include/index.conf;
+    include include/index-staging.conf;
 
     add_header X-Robots-Tag "noindex, nofollow";
     proxy_pass http://site-staging-zh:3000;
@@ -31,16 +31,16 @@ server {
 
   server_name en.cofacts.hacktabl.org dev-en.cofacts.org  dev-en.cofacts.tw;
 
-  include ../include/server.conf;
+  include include/server.conf;
 
   location /_next {
-    include ../include/next.conf;
+    include include/next.conf;
     proxy_pass http://site-staging-en:3000;
   }
 
   location / {
-    include ../include/index.conf;
-    include ../include/index-staging.conf;
+    include include/index.conf;
+    include include/index-staging.conf;
 
     add_header X-Robots-Tag "noindex, nofollow";
     proxy_pass http://site-staging-en:3000;


### PR DESCRIPTION
Nginx `include` directive is relative to nginx root rather than the file that writes `include` directive.