### PR TITLE
Support www.cofacts.org

### DIFF
--- a/volumes/nginx/sites-enabled/rumors-site
+++ b/volumes/nginx/sites-enabled/rumors-site
@@ -51,7 +51,7 @@ server {
 server {
   listen 80;
   listen [::]:80;
-  server_name cofacts.org cofacts.tw;
+  server_name cofacts.tw cofacts.org www.cofacts.org;
 
   include include/server.conf;
 


### PR DESCRIPTION
For some reason, there are some Cofacts pages indexed as "www.cofacts.org" in search engines:
![image](https://user-images.githubusercontent.com/108608/111417705-5da99f00-8721-11eb-8376-922a5f3de60a.png)

This PR adds back www.cofacts.org support.