### PR TITLE
Support Japanese version

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -103,6 +103,18 @@ services:
       - PUBLIC_GA_TRACKING_ID=
     restart: always
 
+  site-staging-ja:
+    image: cofacts/rumors-site:latest-ja
+    environment:
+      - PORT=3000
+      - ROLLBAR_SERVER_TOKEN=CHANGE_ME
+      - ROLLBAR_ENV=staging
+      - NODE_ENV=production
+      - PUBLIC_API_URL=https://dev-api.cofacts.tw
+      - PUBLIC_APP_ID=RUMORS_SITE
+      - PUBLIC_GA_TRACKING_ID=
+    restart: always
+
   api:
     image: cofacts/rumors-api
     environment:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -58,6 +58,27 @@ services:
       - PUBLIC_SLACK_IFTTT_APPLET_URL=https://ifttt.com/applets/H4Sm5LDF-cofacts-rss-slack
     restart: always
 
+  site-ja:
+    image: cofacts/rumors-site:latest-ja
+    environment:
+      - PORT=3000
+      - NODE_ENV=production
+      - SERVER_ROLLBAR_TOKEN=CHANGE_ME
+      - PUBLIC_ROLLBAR_TOKEN=CHANGE_ME
+      - PUBLIC_ROLLBAR_ENV=production
+      - PUBLIC_API_URL=https://api.cofacts.tw
+      - PUBLIC_GTM_ID=GTM-NJXHKTH
+      - PUBLIC_GA_TRACKING_ID=
+      - SERVER_STACKIMPACT_AGENT_KEY=
+      - SERVER_STACKIMPACT_APP_NAME=
+      - PM2_PUBLIC_KEY=
+      - PM2_SECRET_KEY=
+      - WEB_CONCURRENCY=1
+      - PUBLIC_LINE_IFTTT_APPLET_URL=https://ifttt.com/applets/VrzvihCR-cofacts-rss-line
+      - PUBLIC_TELEGRAM_IFTTT_APPLET_URL=https://ifttt.com/applets/WRuZeP36-cofacts-rss-telegram
+      - PUBLIC_SLACK_IFTTT_APPLET_URL=https://ifttt.com/applets/H4Sm5LDF-cofacts-rss-slack
+    restart: always
+
   site-staging-en:
     image: cofacts/rumors-site:latest-en
     environment:
@@ -93,7 +114,7 @@ services:
       - ROLLBAR_ENV=production
       - HTTP_HEADER_APP_ID=x-app-id
       - HTTP_HEADER_APP_SECRET=x-app-secret
-      - RUMORS_SITE_CORS_ORIGIN=https://cofacts.tw,https://en.cofacts.tw,https://cofacts.g0v.tw,https://cofacts.org,https://old.cofacts.org,https://en.cofacts.org
+      - RUMORS_SITE_CORS_ORIGIN=https://cofacts.tw,https://en.cofacts.tw,https://cofacts.g0v.tw,https://cofacts.org,https://old.cofacts.org,https://en.cofacts.org,https://ja.cofacts.tw
       - RUMORS_SITE_REDIRECT_ORIGIN=https://cofacts.tw,https://en.cofacts.tw
       - RUMORS_LINE_BOT_CORS_ORIGIN=https://rumors-line-bot.herokuapp.com
       - RUMORS_LINE_BOT_SECRET=CHANGE_ME

--- a/volumes/nginx/include/index-prod.conf
+++ b/volumes/nginx/include/index-prod.conf
@@ -3,3 +3,4 @@
 # hreflangs (identical for each locale)
 add_header Link "<https://cofacts.tw$request_uri>; rel=\"alternate\"; hreflang=\"zh\"";
 add_header Link "<https://en.cofacts.tw$request_uri>; rel=\"alternate\"; hreflang=\"en\"";
+add_header Link "<https://ja.cofacts.tw$request_uri>; rel=\"alternate\"; hreflang=\"ja\"";

--- a/volumes/nginx/include/index-staging.conf
+++ b/volumes/nginx/include/index-staging.conf
@@ -3,3 +3,4 @@
 # hreflangs (identical for each locale)
 add_header Link "<https://dev.cofacts.tw$request_uri>; rel=\"alternate\"; hreflang=\"zh\"";
 add_header Link "<https://dev-en.cofacts.tw$request_uri>; rel=\"alternate\"; hreflang=\"en\"";
+add_header Link "<https://dev-ja.cofacts.tw$request_uri>; rel=\"alternate\"; hreflang=\"ja\"";

--- a/volumes/nginx/sites-enabled/rumors-site
+++ b/volumes/nginx/sites-enabled/rumors-site
@@ -94,3 +94,27 @@ server {
     add_header Link "<https://en.cofacts.tw$request_uri>; rel=\"canonical\"";
   }
 }
+
+# ja
+server {
+  listen 80;
+  listen [::]:80;
+  server_name ja.cofacts.org ja.cofacts.tw;
+
+  include include/server.conf;
+
+  location /_next {
+    include include/next.conf;
+    proxy_pass http://site-ja:3000;
+  }
+
+  location / {
+    include include/index.conf;
+    include include/index-prod.conf;
+
+    proxy_pass http://site-ja:3000;
+
+    # Canonical to ja.cofacts.tw
+    add_header Link "<https://ja.cofacts.tw$request_uri>; rel=\"canonical\"";
+  }
+}

--- a/volumes/nginx/sites-enabled/rumors-site-staging
+++ b/volumes/nginx/sites-enabled/rumors-site-staging
@@ -49,3 +49,29 @@ server {
     add_header Link "<https://dev-en.cofacts.tw$request_uri>; rel=\"canonical\"";
   }
 }
+
+# ja
+server {
+  listen 80;
+  listen [::]:80;
+
+  server_name dev-ja.cofacts.tw;
+
+  include include/server.conf;
+
+  location /_next {
+    include include/next.conf;
+    proxy_pass http://site-staging-ja:3000;
+  }
+
+  location / {
+    include include/index.conf;
+    include include/index-staging.conf;
+
+    add_header X-Robots-Tag "noindex, nofollow";
+    proxy_pass http://site-staging-ja:3000;
+
+    # Canonical to dev-ja.cofacts.tw
+    add_header Link "<https://dev-ja.cofacts.tw$request_uri>; rel=\"canonical\"";
+  }
+}


### PR DESCRIPTION
Deploy `site-ja` and setup `api`'s CORS domain