### PR TITLE
301 redirect cofacts.g0v.tw to cofacts.tw

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -188,7 +188,7 @@ services:
       - ROLLBAR_ENV=production
       - HTTP_HEADER_APP_ID=x-app-id
       - HTTP_HEADER_APP_SECRET=x-app-secret
-      - RUMORS_SITE_CORS_ORIGIN=https://cofacts.tw,https://en.cofacts.tw,https://cofacts.g0v.tw,https://cofacts.org,https://old.cofacts.org,https://en.cofacts.org,https://ja.cofacts.tw
+      - RUMORS_SITE_CORS_ORIGIN=https://cofacts.tw,https://en.cofacts.tw,https://cofacts.g0v.tw,https://ja.cofacts.tw
       - RUMORS_SITE_REDIRECT_ORIGIN=https://cofacts.tw,https://en.cofacts.tw
       - RUMORS_LINE_BOT_CORS_ORIGIN=https://rumors-line-bot.herokuapp.com
       - RUMORS_LINE_BOT_SECRET=CHANGE_ME
@@ -234,7 +234,7 @@ services:
       - ROLLBAR_ENV=staging
       - HTTP_HEADER_APP_ID=x-app-id
       - HTTP_HEADER_APP_SECRET=x-app-secret
-      - RUMORS_SITE_CORS_ORIGIN=https://dev.cofacts.tw,https://dev.cofacts.org,https://dev-en.cofacts.org,https://dev-en.cofacts.tw,http://localhost:3000
+      - RUMORS_SITE_CORS_ORIGIN=https://dev.cofacts.tw,https://dev-en.cofacts.tw,http://localhost:3000
       - RUMORS_SITE_REDIRECT_ORIGIN=https://dev.cofacts.tw,https://dev-en.cofacts.tw,http://localhost:3000
       - RUMORS_LINE_BOT_CORS_ORIGIN=https://rumors-line-bot-staging.herokuapp.com,http://localhost:5001
       - RUMORS_LINE_BOT_SECRET=CHANGE_ME

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -188,7 +188,7 @@ services:
       - ROLLBAR_ENV=production
       - HTTP_HEADER_APP_ID=x-app-id
       - HTTP_HEADER_APP_SECRET=x-app-secret
-      - RUMORS_SITE_CORS_ORIGIN=https://cofacts.tw,https://en.cofacts.tw,https://cofacts.g0v.tw,https://ja.cofacts.tw
+      - RUMORS_SITE_CORS_ORIGIN=https://cofacts.tw,https://en.cofacts.tw,https://ja.cofacts.tw
       - RUMORS_SITE_REDIRECT_ORIGIN=https://cofacts.tw,https://en.cofacts.tw
       - RUMORS_LINE_BOT_CORS_ORIGIN=https://rumors-line-bot.herokuapp.com
       - RUMORS_LINE_BOT_SECRET=CHANGE_ME

--- a/env-files.sample/line-bot-zh
+++ b/env-files.sample/line-bot-zh
@@ -5,8 +5,8 @@ ROLLBAR_CLIENT_TOKEN=
 GA_ID=
 LIFF_URL=https://liff.line.me/<liff-id>
 APP_ID=RUMORS_LINE_BOT
-API_URL=https://api.cofacts.org/graphql
-SITE_URLS=https://cofacts.org,http://cofacts.org,https://cofacts.tw,https://cofacts.g0v.tw
+API_URL=https://api.cofacts.tw/graphql
+SITE_URLS=http://cofacts.tw,https://cofacts.g0v.tw
 
 # Runtime secrets
 LINE_CHANNEL_SECRET=

--- a/volumes/nginx/nginx.conf
+++ b/volumes/nginx/nginx.conf
@@ -13,9 +13,8 @@ http {
   include       /etc/nginx/mime.types;
   default_type  application/octet-stream;
 
-  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-            '$status $body_bytes_sent "$http_referer" '
-            '"$http_user_agent" "$http_x_forwarded_for"';
+  log_format  main '$remote_addr [$time_local] "$host" "$request" '
+            '$status $body_bytes_sent "$http_user_agent" "$http_x_forwarded_for"';
 
   access_log  /var/log/nginx/access.log  main;
 

--- a/volumes/nginx/sites-enabled/rumors-site
+++ b/volumes/nginx/sites-enabled/rumors-site
@@ -51,7 +51,7 @@ server {
 server {
   listen 80;
   listen [::]:80;
-  server_name cofacts.tw cofacts.org www.cofacts.org;
+  server_name cofacts.tw;
 
   include include/server.conf;
 
@@ -75,7 +75,7 @@ server {
 server {
   listen 80;
   listen [::]:80;
-  server_name en.cofacts.org en.cofacts.tw;
+  server_name en.cofacts.tw;
 
   include include/server.conf;
 
@@ -99,7 +99,7 @@ server {
 server {
   listen 80;
   listen [::]:80;
-  server_name ja.cofacts.org ja.cofacts.tw;
+  server_name ja.cofacts.tw;
 
   include include/server.conf;
 

--- a/volumes/nginx/sites-enabled/rumors-site
+++ b/volumes/nginx/sites-enabled/rumors-site
@@ -1,9 +1,9 @@
-# http cofacts.g0v.tw --> https
+# http://cofacts.g0v.tw --> https://cofacts.tw
 server {
   listen 80 default_server;
   listen [::]:80 default_server;
   server_name cofacts.g0v.tw;
-  return 301 https://$host$request_uri;
+  return 301 https://cofacts.tw$request_uri;
 }
 
 # zh_TW, cofacts.g0v.tw with self-managed SSL
@@ -24,21 +24,8 @@ server {
   ssl_stapling_verify on;
   add_header Strict-Transport-Security max-age=15768000;
 
-  include include/server.conf;
-
-  location /_next {
-    include include/next.conf;
-    proxy_pass http://site-zh:3000;
-  }
-
   location / {
-    include include/index.conf;
-    include include/index-prod.conf;
-
-    proxy_pass http://site-zh:3000;
-
-    # Canonical to cofacts.tw
-    add_header Link "<https://cofacts.tw$request_uri>; rel=\"canonical\"";
+    return 302 https://cofacts.tw$request_uri;
   }
 
   location ~ /.well-known {

--- a/volumes/nginx/sites-enabled/rumors-site
+++ b/volumes/nginx/sites-enabled/rumors-site
@@ -25,7 +25,7 @@ server {
   add_header Strict-Transport-Security max-age=15768000;
 
   location / {
-    return 302 https://cofacts.tw$request_uri;
+    return 301 https://cofacts.tw$request_uri;
   }
 
   location ~ /.well-known {

--- a/volumes/nginx/sites-enabled/rumors-site-staging
+++ b/volumes/nginx/sites-enabled/rumors-site-staging
@@ -3,7 +3,7 @@ server {
   listen 80;
   listen [::]:80;
 
-  server_name cofacts.hacktabl.org dev.cofacts.org dev.cofacts.tw;
+  server_name dev.cofacts.tw;
 
   include include/server.conf;
 
@@ -29,7 +29,7 @@ server {
   listen 80;
   listen [::]:80;
 
-  server_name en.cofacts.hacktabl.org dev-en.cofacts.org  dev-en.cofacts.tw;
+  server_name dev-en.cofacts.tw;
 
   include include/server.conf;
 


### PR DESCRIPTION
As discussed in 20230223 meeting https://g0v.hackmd.io/r39Cc0RWT0GBuyOvLur2eA#Op-layer-API-access-management - use 301 redirect to convert `cofacts.org` to `cofacts.tw` (done in Cloudflare)
- 301 redirect `cofacts.g0v.tw` to `cofacts.tw` as well
- Adjust nginx log, remove fields always in `-` and add host to see the host of incoming HTTP request
    - Check if Cloudflare redirect works (so that no request with `cofacts.org` is sent to nginx)
    - Check the usage of `cofacts-api.g0v.tw` (may be used by third party; not managed by Cloudflare)
