### PR TITLE
fix: avoid port 6000

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -195,7 +195,7 @@ services:
       - ELASTICSEARCH_URL=http://db:9200
       - ELASTIC_LOG_LEVEL=info
       - PORT=5000
-      - ADM_PORT=6000
+      - ADM_PORT=5500
       - COOKIE_SECRETS=
       - ROLLBAR_TOKEN=CHANGE_ME
       - ROLLBAR_ENV=production
@@ -334,7 +334,7 @@ services:
       - "./volumes/redis/redis.conf:/usr/local/etc/redis/redis.conf"
     command: redis-server /usr/local/etc/redis/redis.conf
     restart: always
-  
+
   collab-server:
     image: cofacts/collab-server
     environment:


### PR DESCRIPTION
- Port 6000 is for x11, we had better avoid it
- Ref: https://www.reddit.com/r/firefox/comments/ttms50/since_when_was_this_a_thing_in_firefox_trying_to/