### PR TITLE
Add Cloudflare access settings

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -196,6 +196,7 @@ services:
       - ELASTIC_LOG_LEVEL=info
       - PORT=5000
       - ADM_PORT=5500
+      - CLOUDFLARE_ACCESS_TEAM_DOMAIN=cofacts.cloudflareaccess.com
       - COOKIE_SECRETS=
       - ROLLBAR_TOKEN=CHANGE_ME
       - ROLLBAR_ENV=production

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -196,7 +196,7 @@ services:
       - ELASTIC_LOG_LEVEL=info
       - PORT=5000
       - ADM_PORT=5500
-      - CLOUDFLARE_ACCESS_TEAM_DOMAIN=cofacts.cloudflareaccess.com
+      - CLOUDFLARE_ACCESS_TEAM_DOMAIN=https://cofacts.cloudflareaccess.com
       - COOKIE_SECRETS=
       - ROLLBAR_TOKEN=CHANGE_ME
       - ROLLBAR_ENV=production


### PR DESCRIPTION
The env is required for Admin API to verify JWT tokens from Cloudflare.

Related to cofacts/rumors-api#337 .