### PR TITLE
feat: Add Langfuse configuration to docker-compose environment variables

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -235,6 +235,9 @@ services:
       - GCS_IMAGE_FOLDER=
       - INTERNET_ARCHIVE_S3_ACCESS_KEY=
       - INTERNET_ARCHIVE_S3_SECRET_KEY=
+      - LANGFUSE_PUBLIC_KEY=
+      - LANGFUSE_SECRET_KEY=
+      - LANGFUSE_HOST=https://langfuse.cofacts.tw
     volumes:
       - "./volumes/api:/data"
     restart: always
@@ -282,6 +285,9 @@ services:
       - GCS_IMAGE_FOLDER=
       - INTERNET_ARCHIVE_S3_ACCESS_KEY=
       - INTERNET_ARCHIVE_S3_SECRET_KEY=
+      - LANGFUSE_PUBLIC_KEY=
+      - LANGFUSE_SECRET_KEY=
+      - LANGFUSE_HOST=https://langfuse.cofacts.tw
     volumes:
       - "./volumes/api:/data"
     restart: always

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -27,6 +27,9 @@ services:
       - COOKIE_SECRETS=
       - ROLLBAR_TOKEN=
       - ROLLBAR_ENV=production
+      - LANGFUSE_PUBLIC_KEY=
+      - LANGFUSE_SECRET_KEY=
+      - LANGFUSE_HOST=http://langfuse:3000
       - HTTP_HEADER_APP_ID=x-app-id
       - HTTP_HEADER_APP_SECRET=x-app-secret
       - RUMORS_SITE_CORS_ORIGIN=http://localhost:3000


### PR DESCRIPTION
Add Langfuse environment variables to docker-compose files for production and sample environments.

Related to cofacts/rumors-api#355