### PR TITLE
fix: update Langfuse environment variable name

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -237,7 +237,7 @@ services:
       - INTERNET_ARCHIVE_S3_SECRET_KEY=
       - LANGFUSE_PUBLIC_KEY=
       - LANGFUSE_SECRET_KEY=
-      - LANGFUSE_HOST=https://langfuse.cofacts.tw
+      - LANGFUSE_BASEURL=https://langfuse.cofacts.tw
     volumes:
       - "./volumes/api:/data"
     restart: always
@@ -287,7 +287,7 @@ services:
       - INTERNET_ARCHIVE_S3_SECRET_KEY=
       - LANGFUSE_PUBLIC_KEY=
       - LANGFUSE_SECRET_KEY=
-      - LANGFUSE_HOST=https://langfuse.cofacts.tw
+      - LANGFUSE_BASEURL=https://langfuse.cofacts.tw
     volumes:
       - "./volumes/api:/data"
     restart: always

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -29,7 +29,7 @@ services:
       - ROLLBAR_ENV=production
       - LANGFUSE_PUBLIC_KEY=
       - LANGFUSE_SECRET_KEY=
-      - LANGFUSE_HOST=http://langfuse:3000
+      - LANGFUSE_BASEURL=http://langfuse:3000
       - HTTP_HEADER_APP_ID=x-app-id
       - HTTP_HEADER_APP_SECRET=x-app-secret
       - RUMORS_SITE_CORS_ORIGIN=http://localhost:3000


### PR DESCRIPTION
Update LANGFUSE_HOST to LANGFUSE_BASEURL to match [Langfuse NodeJS SDK](https://langfuse.com/docs/integrations/openai/js/get-started)'s environment variable name.