### PR TITLE
Add ADK and AI site services to production docker-compose

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -199,6 +199,18 @@ services:
         gcp-meta-id: langfuse
         gcp-project: <GCP project>
 
+  adk:
+    image: cofacts/adk:latest
+    env_file:
+      - ./env-files/adk
+    restart: always
+
+  ai-site:
+    image: cofacts/site:latest
+    env_file:
+      - ./env-files/ai-site
+    restart: always
+
   # Primarily for Langfuse
   cloudsql-proxy:
     image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.0

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -204,12 +204,22 @@ services:
     env_file:
       - ./env-files/adk
     restart: always
+    logging:
+      driver: gcplogs
+      options:
+        gcp-meta-id: adk
+        gcp-project: <GCP project>
 
   ai-site:
     image: cofacts/site:latest
     env_file:
       - ./env-files/ai-site
     restart: always
+    logging:
+      driver: gcplogs
+      options:
+        gcp-meta-id: ai-site
+        gcp-project: <GCP project>
 
   # Primarily for Langfuse
   cloudsql-proxy:

--- a/env-files.sample/adk
+++ b/env-files.sample/adk
@@ -1,0 +1,1 @@
+# Add environment variables here

--- a/env-files.sample/adk
+++ b/env-files.sample/adk
@@ -1,1 +1,7 @@
-# Add environment variables here
+GOOGLE_API_KEY=your-google-api-key-here
+PORT=8000
+HOST=0.0.0.0
+# COFACTS_API_URL=https://api.cofacts.tw/graphql
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+# LANGFUSE_HOST=

--- a/env-files.sample/ai-site
+++ b/env-files.sample/ai-site
@@ -1,0 +1,1 @@
+# Add environment variables here

--- a/env-files.sample/ai-site
+++ b/env-files.sample/ai-site
@@ -1,1 +1,5 @@
-# Add environment variables here
+PORT=3000
+VITE_API_URL=https://api.cofacts.tw
+VITE_ADK_URL=http://adk:8000
+# GOOGLE_ANALYTICS_ID=
+# SENTRY_DSN=


### PR DESCRIPTION
Added adk and ai-site services to docker-compose.production.yml using images from cofacts/ai. Created placeholder env files in env-files.sample/.

---
*PR created automatically by Jules for task [929208404470990086](https://jules.google.com/task/929208404470990086) started by @MrOrz*