### PR TITLE
feat: add cofacts-ai services and adk env template to sample compose

### DIFF
--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -73,9 +73,10 @@ services:
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 60s
+      start_interval: 5s
       timeout: 5s
       retries: 6
-      start_period: 10s
+      start_period: 60s
 
   # cofacts.ai website frontend
   cofacts-ai:

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -72,7 +72,7 @@ services:
       - LANGFUSE_BASE_URL=https://langfuse.cofacts.tw
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
-      interval: 10s
+      interval: 60s
       timeout: 5s
       retries: 6
       start_period: 10s

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
 
   site:
@@ -61,3 +60,31 @@ services:
     volumes:
       - "./data/mongo:/data/db"
     command: mongod
+
+  # cofacts.ai AI agent backend (ADK)
+  adk:
+    image: cofacts/adk:latest
+    restart: always
+    env_file:
+      - ./env-files/adk
+    environment:
+      - PORT=8000
+      - LANGFUSE_BASE_URL=https://langfuse.cofacts.tw
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
+
+  # cofacts.ai website frontend
+  cofacts-ai:
+    image: cofacts/site:latest
+    restart: always
+    environment:
+      - PORT=3000
+      - ADK_URL=http://adk:8000
+      - PUBLIC_URL=https://cofacts.ai
+    depends_on:
+      adk:
+        condition: service_healthy

--- a/env-files.sample/adk
+++ b/env-files.sample/adk
@@ -1,7 +1,7 @@
-GOOGLE_API_KEY=your-google-api-key-here
-PORT=8000
-HOST=0.0.0.0
-# COFACTS_API_URL=https://api.cofacts.tw/graphql
-# LANGFUSE_PUBLIC_KEY=
-# LANGFUSE_SECRET_KEY=
-# LANGFUSE_HOST=
+# Google Gemini API key (https://aistudio.google.com/app/apikey)
+GOOGLE_API_KEY=
+
+# Langfuse credentials (https://langfuse.cofacts.tw → Project Settings)
+# Optional: skip to disable Langfuse instrumentation
+LANGFUSE_PUBLIC_KEY=pk-lf-
+LANGFUSE_SECRET_KEY=sk-lf-


### PR DESCRIPTION
Add cofacts-ai frontend and adk backend services to docker-compose.sample.yml, and add env-files.sample/adk template.

- adk healthcheck: interval 60s (reduce log noise), start_interval 5s (fast healthy detection on startup), start_period 60s